### PR TITLE
Changed submodules protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/xpath.js"]
 	path = src/xpath.js
-	url = git://github.com/ilinsky/xpath.js.git
+	url = https://github.com/ilinsky/xpath.js.git


### PR DESCRIPTION
The git:// protocol is deprecate. Change to
use https://.